### PR TITLE
[Improvements] Add hasPrepared method for Android & Fix prepare crash

### DIFF
--- a/android/src/main/kotlin/io/xdea/flutter_vpn/FlutterVpnPlugin.kt
+++ b/android/src/main/kotlin/io/xdea/flutter_vpn/FlutterVpnPlugin.kt
@@ -100,7 +100,7 @@ class FlutterVpnPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
   override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
     when (call.method) {
       "hasPrepared" -> {
-        val intent = VpnService.prepare(registrar.activeContext())
+        val intent = VpnService.prepare(activityBinding.activity.applicationContext)
         result.success(intent == null)
       }
       "prepare" -> {

--- a/lib/flutter_vpn.dart
+++ b/lib/flutter_vpn.dart
@@ -71,9 +71,15 @@ class FlutterVpn {
   /// you should prepare again before reconnect.
   ///
   /// Do nothing in iOS.
-  static Future<Null> prepare() async {
-    if (!Platform.isAndroid) return Null;
+  static Future<bool> prepare() async {
+    if (!Platform.isAndroid) return true;
     return await _channel.invokeMethod('prepare');
+  }
+
+  static Future<bool> hasPrepared() async {
+    if (!Platform.isAndroid) return true;
+    final response = await _channel.invokeMethod('hasPrepared');
+    return response;
   }
 
   /// Disconnect and stop VPN service.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_vpn
 description: Plugin for developers to access VPN service in their flutter app.
-version: 0.8.0
+version: 0.8.1
 authors:
   - Jason C.H <ctrysbita@outlook.com>
   - Jerry Wang <realflyingblu@gmail.com>


### PR DESCRIPTION
## Purpose
Fix two issues encountered when using the library:
1.) The library does not remove the activity listener when the callback is completed, this causes crashes downstream. For example, if you prompt the user for a vpn connection (calling prepare) and reject this two times, the app crashes since it tries to also invoke a return value on the old Method result
2.) There is no way to check if the user has already configured the VPN, exposing a method for this